### PR TITLE
feat: add homeApp to redirect / to the dashboard

### DIFF
--- a/site.config.build.tsx
+++ b/site.config.build.tsx
@@ -1,6 +1,7 @@
 import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
 import { authnApp } from '@openedx/frontend-app-authn';
 import { learnerDashboardApp } from '@openedx/frontend-app-learner-dashboard';
+import homeApp from './src/homeApp';
 
 import './src/site.scss';
 
@@ -19,6 +20,7 @@ const siteConfig: SiteConfig = {
     footerApp,
     authnApp,
     learnerDashboardApp,
+    homeApp,
   ],
   externalRoutes: [
     {

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -1,6 +1,7 @@
 import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@openedx/frontend-base';
 import { authnApp } from '@openedx/frontend-app-authn';
 import { learnerDashboardApp } from '@openedx/frontend-app-learner-dashboard';
+import homeApp from './src/homeApp';
 
 import './src/site.scss';
 
@@ -19,6 +20,7 @@ const siteConfig: SiteConfig = {
     footerApp,
     authnApp,
     learnerDashboardApp,
+    homeApp,
   ],
   externalRoutes: [
     {

--- a/src/homeApp.ts
+++ b/src/homeApp.ts
@@ -1,0 +1,18 @@
+import { App, getUrlByRouteRole } from '@openedx/frontend-base';
+import { redirect } from 'react-router';
+
+const homeApp: App = {
+  appId: 'home',
+  routes: [{
+    path: '/',
+    loader: () => {
+      const dashboardUrl = getUrlByRouteRole('org.openedx.frontend.role.dashboard');
+      if (dashboardUrl) {
+        return redirect(dashboardUrl);
+      }
+      throw new Response('Not Found', { status: 404 });
+    },
+  }],
+};
+
+export default homeApp;


### PR DESCRIPTION
### Description

Add an inline homeApp that registers a route at `/` and redirects to the learner dashboard via `getUrlByRouteRole`, shared across both dev and build site configs. If the dashboard role isn't found, nothing is rendered.

### LLM usage notice

Built with assistance from Claude models (mostly Opus 4.6).