### PR TITLE
fix: conform site.scss to new frontend-base CSS ownership model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,11 @@
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
+        "@openedx/brand-openedx": "^2.0.0",
         "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
         "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",
         "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-app-notifications": "^3.0.0-alpha || 0.0.0-dev",
         "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
       },
       "devDependencies": {
@@ -1856,9 +1857,9 @@
       "peer": true
     },
     "node_modules/@bundled-es-modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1970,20 +1971,20 @@
       }
     },
     "node_modules/@bundled-es-modules/memfs/node_modules/memfs": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.1.tgz",
-      "integrity": "sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -2010,46 +2011,44 @@
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.2.0.tgz",
-      "integrity": "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@chevrotain/gast": "11.2.0",
-        "@chevrotain/types": "11.2.0",
-        "lodash-es": "4.17.23"
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.2.0.tgz",
-      "integrity": "sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@chevrotain/types": "11.2.0",
-        "lodash-es": "4.17.23"
+        "@chevrotain/types": "12.0.0"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.2.0.tgz",
-      "integrity": "sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.2.0.tgz",
-      "integrity": "sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.2.0.tgz",
-      "integrity": "sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "license": "Apache-2.0",
       "peer": true
     },
@@ -2149,13 +2148,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@edx/brand": {
-      "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
-      "license": "GPL-3.0-or-later"
-    },
     "node_modules/@edx/browserslist-config": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.5.1.tgz",
@@ -2182,9 +2174,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2271,9 +2263,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2352,9 +2344,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2432,9 +2424,9 @@
       }
     },
     "node_modules/@formatjs/cli": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.14.1.tgz",
-      "integrity": "sha512-afBgzduP4lrOEm1FxMAVMXKi2FNE7KDOWJ7SyhvEI7zRbHhA7qVkb2DbxpPUhtDg0BrdHjdp8ppVyVVNYaFaaA==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.14.2.tgz",
+      "integrity": "sha512-0aZLIRcrxIf6QU2u04bIorYIVA1Sm8hHlHzlK9ROGB2BLN0WbiBCwK3jAPV9um+pPS6O4ZFT6K9c2j/3iMkmSw==",
       "license": "MIT",
       "bin": {
         "formatjs": "bin/formatjs"
@@ -2731,6 +2723,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-7Z/ur0gvCMW8G93dXIQOkQqHo2M5HLhYrRVC0//fakJXxcF1VmMPsxnG6Ee8qEylA8b8Q3peQXWMNZ62lYF28g==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@fortawesome/free-solid-svg-icons": {
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
@@ -2758,23 +2762,36 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -3318,9 +3335,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3736,13 +3753,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.1.tgz",
-      "integrity": "sha512-YrEi/ZPmgc+GfdO0esBF04qv8boK9Dg9WpRQw/+vM8Qt3nnVIJWIa8HwZ/LXVZ0DB11XUROM8El/7yYTJX+WtA==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+      "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -3757,14 +3774,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.1.tgz",
-      "integrity": "sha512-ooEPvSW/HQDivPDPZMibHGKZf/QS4WRir1czGZmXmp3MsQqLECZEpN0JobrD8iV9BzsuwdIv+PxtWX9WpPLsIA==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+      "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -3779,16 +3796,16 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.1.tgz",
-      "integrity": "sha512-3YaKhP8gXEKN+2O49GLNfNb5l2gbnCFHyAaybbA2JkkbQP3dpdef7WcUaHAulg/c5Dg4VncHsA3NWAUSZMR5KQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+      "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -3804,9 +3821,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.1.tgz",
-      "integrity": "sha512-XHkFKQ5GSH3uxm8c3ZYXVrexGdscpWKIcMWKFQpMpMJc8gA3AwOMBJXJlgpdJqmrhPyQXxaY9nbkNeYpacC0Og==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.0"
@@ -3820,14 +3837,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.1.tgz",
-      "integrity": "sha512-pqGHyWWzNck4jRfaGV39hkqpY5QjRUQ/nRbNT7FYbBa0xf4bDG+TE1Gt2KWZrSkrkZZDE3qZUjYMbjwSliX6pg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+      "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1"
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -3841,12 +3858,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.1.tgz",
-      "integrity": "sha512-vp+7ZzIB8v43G+GLXTS4oDUSQmhAsRz532QmmWBbdYA20s465JvwhkSFvX9cVTqRRAQg+vZ7zWDaIEh0lFe2gw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+      "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.1"
+        "@jsonjoy.com/fs-node-builtins": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -3860,12 +3877,12 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.1.tgz",
-      "integrity": "sha512-Ynct7ZJmfk6qoXDOKfpovNA36ITUx8rChLmRQtW08J73VOiuNsU8PB6d/Xs7fxJC2ohWR3a5AqyjmLojfrw5yw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+      "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -3880,13 +3897,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.1.tgz",
-      "integrity": "sha512-/oG8xBNFMbDXTq9J7vepSA1kerS5vpgd3p5QZSPd+nX59uwodGJftI51gDYyHRpP57P3WCQf7LHtBYPqwUg2Bg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+      "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -4164,16 +4181,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@openedx/brand-openedx": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-2.0.4.tgz",
+      "integrity": "sha512-3iGs4ZjfOsyN1msP+Wn/k11qL4g0CJGpKWGH5f248n+dZrGzZnhyz2CEo4TCRRMqOcQroSX5WBIuZR4vUla0Sg==",
+      "license": "GPL-3.0-or-later"
+    },
     "node_modules/@openedx/frontend-app-authn": {
-      "version": "1.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0-alpha.11.tgz",
-      "integrity": "sha512-Bbl970mXIIe4PXeHnLhZmfo4kr2Gz2xNsVqpBVfrQ4mT1h1UTP7Kipd0P31XJKqUwVt331uRYw9/+TMQNJztGg==",
+      "version": "1.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0-alpha.12.tgz",
+      "integrity": "sha512-R2SfbTqg6RJB8hL52ZSo6WDMoYP3rMR/0g0ApqUScZ5sfvaSSHDZv3DGT7rmw5Dyeb6xgn2TEe00iQfZmO+0iA==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
@@ -4204,15 +4226,14 @@
       }
     },
     "node_modules/@openedx/frontend-app-instructor-dashboard": {
-      "version": "1.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0-alpha.9.tgz",
-      "integrity": "sha512-6m9xzjQm6ScqgCM7tFFlKhdwZd5fY4/nHEgB0bPSvkIe/p0Fy3QZPrdhItDB9VpS624WZKsgVg/IDkZGQi1XuQ==",
+      "version": "1.0.0-alpha.18",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0-alpha.18.tgz",
+      "integrity": "sha512-gEPh9wkaz7j6k0QkYoUagvvnHog3nQn41lJIeTNkBfQzGa1IcyEqX6RJH/27Zx4oiTjQEdXFOOw0zsTc117CHw==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
         "lodash": "^4.17.23"
       },
@@ -4227,15 +4248,14 @@
       }
     },
     "node_modules/@openedx/frontend-app-learner-dashboard": {
-      "version": "1.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0-alpha.13.tgz",
-      "integrity": "sha512-ZbryvBABmnrmqLDEY7Pl+HvAqpEx4fZKz9xF/H2FCGx96yiOl2EuOukNFDc82eXjoj8qstaOhqDwRX6K5fBWvQ==",
+      "version": "1.0.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0-alpha.14.tgz",
+      "integrity": "sha512-nN+NBwOJV31XiqmbZhmMc2J6Sv7otJpD7B0R8SZzR+BwtKw6LJchi7FrxDbBtrv3dqy4DitfBrQHUaRN9Dp/FQ==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
@@ -4309,10 +4329,53 @@
         "node": ">=6"
       }
     },
+    "node_modules/@openedx/frontend-app-notifications": {
+      "version": "3.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-3.0.0-alpha.2.tgz",
+      "integrity": "sha512-RHJcbEADKiFcuY53uPCtp2YurbO0ATcejN9SSBeV2kYKgmuatX8NkM/DSujoz8TqeZWSbXn0G7QUjvw9NgDpKw==",
+      "license": "AGPL-3.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-brands-svg-icons": "^6.6.0",
+        "@fortawesome/free-regular-svg-icons": "^6.6.0",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/react-fontawesome": "^0.2.2",
+        "classnames": "^2.5.1",
+        "dompurify": "^3.1.7",
+        "lodash": "^4.18.1",
+        "timeago.js": "^4.0.2",
+        "uuid": "^13.0.0"
+      },
+      "peerDependencies": {
+        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/paragon": "^23",
+        "@tanstack/react-query": "^5",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-router": "^6",
+        "react-router-dom": "^6"
+      }
+    },
+    "node_modules/@openedx/frontend-app-notifications/node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.27.tgz",
-      "integrity": "sha512-86rbiHyAoNCa+aGShO5jPQgYrjJMRG58VmNG+q7cA3fMkqzOawX9GKjbpoSxEeLiUXt3ZflrbKHEpUBPYLtBwg==",
+      "version": "1.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.34.tgz",
+      "integrity": "sha512-re5fbcahqL9SMqqCZd07msgy3sbLsymCCbOdysYcOTunuC/vqQyZeWEue4cadHdW76vP7c1vX2OYrvBK8lKiVQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.24.9",
@@ -4354,7 +4417,7 @@
         "glob": "^7.2.3",
         "globals": "^15.11.0",
         "gradient-string": "^2.0.2",
-        "html-webpack-plugin": "5.6.0",
+        "html-webpack-plugin": "5.6.7",
         "identity-obj-proxy": "3.0.0",
         "image-minimizer-webpack-plugin": "3.8.3",
         "jest": "^29.7.0",
@@ -4448,9 +4511,9 @@
       "license": "MIT"
     },
     "node_modules/@openedx/paragon": {
-      "version": "23.20.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.20.0.tgz",
-      "integrity": "sha512-2LOzROn0mkNpeaHjaGMnwgJYIY7CZSHFh7iYq3VB7IViMGo6eD+LboPoY5T48pnYVdDTTgiN3YLTI0h+mt5CwQ==",
+      "version": "23.21.2",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-23.21.2.tgz",
+      "integrity": "sha512-CBRAIWIk93Dp8U8WFk56pnu8GLoJCPGKVY/s0P3aq+bYeM4+YnN303Ex9jYlhmZztjRPW4P5Cx+xuXXuBKkfoA==",
       "license": "Apache-2.0",
       "peer": true,
       "workspaces": [
@@ -4463,17 +4526,17 @@
       "dependencies": {
         "@popperjs/core": "^2.11.4",
         "@tokens-studio/sd-transforms": "^1.2.4",
-        "axios": "^0.30.2",
+        "axios": "^1.0.0",
         "bootstrap": "^4.6.2",
         "chalk": "^4.1.2",
         "child_process": "^1.0.2",
-        "chroma-js": "^2.4.2",
+        "chroma-js": "^3.0.0",
         "classnames": "^2.3.1",
         "cli-progress": "^3.12.0",
         "commander": "^9.4.1",
         "email-prop-type": "^3.0.0",
         "file-selector": "^0.10.0",
-        "glob": "^8.0.3",
+        "glob": "^13.0.0",
         "inquirer": "^8.2.5",
         "js-toml": "^1.0.0",
         "lodash.uniqby": "^4.7.0",
@@ -4515,54 +4578,32 @@
         "react-intl": "^5.25.1 || ^6.4.0"
       }
     },
-    "node_modules/@openedx/paragon/node_modules/axios": {
-      "version": "0.30.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
-      "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@openedx/paragon/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@openedx/paragon/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@openedx/paragon/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@openedx/paragon/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@openedx/paragon/node_modules/matchmediaquery": {
@@ -4575,17 +4616,21 @@
         "css-mediaquery": "^0.1.2"
       }
     },
-    "node_modules/@openedx/paragon/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
+    "node_modules/@openedx/paragon/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@openedx/paragon/node_modules/postcss-custom-media": {
@@ -4616,13 +4661,6 @@
       "peerDependencies": {
         "postcss": "^8.4"
       }
-    },
-    "node_modules/@openedx/paragon/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@openedx/paragon/node_modules/react-responsive": {
       "version": "10.0.1",
@@ -5270,9 +5308,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.99.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
-      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5281,9 +5319,9 @@
       }
     },
     "node_modules/@tanstack/query-devtools": {
-      "version": "5.99.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
-      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.2.tgz",
+      "integrity": "sha512-TEF1d+RYO9l8oeCwgzmOHIgKwAzXQmw2s/ny2bW8qeg2OMkkLjALfVEivgCMR3OL/jVdMmeTPX56WrV+uvYJFg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5291,13 +5329,13 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.99.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
-      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.99.0"
+        "@tanstack/query-core": "5.99.2"
       },
       "funding": {
         "type": "github",
@@ -5308,19 +5346,19 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "5.99.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
-      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.2.tgz",
+      "integrity": "sha512-8txkK9A9XBNTB8RoxVgfp6W3qwBr25tNP10L4yu3KuyhAdEvccECfIRzesSwMVk/wpVVioAr+hbMtUkMMF+WVw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-devtools": "5.99.0"
+        "@tanstack/query-devtools": "5.99.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^5.99.0",
+        "@tanstack/react-query": "^5.99.2",
         "react": "^18 || ^19"
       }
     },
@@ -5869,6 +5907,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/warning": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
@@ -5901,16 +5946,16 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -5923,7 +5968,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -5938,15 +5983,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5962,13 +6007,13 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -5983,13 +6028,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6000,9 +6045,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6016,14 +6061,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6040,9 +6085,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6053,15 +6098,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6092,15 +6137,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6115,12 +6160,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -6842,13 +6887,13 @@
       "license": "MIT"
     },
     "node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
+        "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -6927,9 +6972,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "funding": [
         {
           "type": "opencollective",
@@ -6946,8 +6991,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -6978,18 +7023,18 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
-      "integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -7211,9 +7256,9 @@
       "peer": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
-      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7562,9 +7607,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7638,18 +7683,20 @@
       "peer": true
     },
     "node_modules/chevrotain": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.2.0.tgz",
-      "integrity": "sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.2.0",
-        "@chevrotain/gast": "11.2.0",
-        "@chevrotain/regexp-to-ast": "11.2.0",
-        "@chevrotain/types": "11.2.0",
-        "@chevrotain/utils": "11.2.0",
-        "lodash-es": "4.17.23"
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/child_process": {
@@ -7675,9 +7722,9 @@
       }
     },
     "node_modules/chroma-js": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.6.0.tgz",
-      "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-3.2.0.tgz",
+      "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
       "license": "(BSD-3-Clause AND Apache-2.0)",
       "peer": true
     },
@@ -8921,6 +8968,15 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -8979,9 +9035,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.334",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "version": "1.5.343",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz",
+      "integrity": "sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==",
       "license": "ISC"
     },
     "node_modules/email-prop-type": {
@@ -9476,9 +9532,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9548,9 +9604,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9627,9 +9683,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10251,9 +10307,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10358,9 +10414,9 @@
       "license": "MIT"
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10730,9 +10786,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -10976,9 +11032,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -11124,9 +11180,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "license": "MIT",
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
@@ -13125,13 +13181,13 @@
       "license": "MIT"
     },
     "node_modules/js-toml": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/js-toml/-/js-toml-1.0.3.tgz",
-      "integrity": "sha512-sgyRKshBUSPIlUrbVXYQHReVZUXKHTldaW+Fj7KSan21vgnmMpuAAo00rBvm7W4HQrvZSvv186wNHlIjMPYC/A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/js-toml/-/js-toml-1.1.0.tgz",
+      "integrity": "sha512-ttRqC9rcSsV7diH6CsneXqDJWb0l9Guv2dA/0a3SQwdldCk6qsXN4O7Tg5UQevove7CXaYCcsqBn9wEQiIM3ZQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "chevrotain": "^11.1.1",
+        "chevrotain": "^12.0.0",
         "xregexp": "^5.1.2"
       }
     },
@@ -13261,9 +13317,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -13500,13 +13556,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -14077,9 +14126,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -14918,9 +14967,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -15661,9 +15710,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -16065,9 +16114,9 @@
       "license": "MIT"
     },
     "node_modules/react-dev-utils/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -16890,9 +16939,9 @@
       "license": "MIT"
     },
     "node_modules/recursive-readdir/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -17082,11 +17131,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -17281,14 +17331,14 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -19015,9 +19065,9 @@
       "peer": true
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19153,9 +19203,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -19207,6 +19257,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
+    },
+    "node_modules/timeago.js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
+      "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==",
       "license": "MIT"
     },
     "node_modules/tinycolor2": {
@@ -19606,15 +19662,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.1",
-        "@typescript-eslint/parser": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1"
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20065,9 +20121,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.1.tgz",
-      "integrity": "sha512-EW8af29ak8Oaf4T8k8YsajjrDBDYgnKZ5er6ljWFJsXABfTNowQfvHLftwcepVgdz+IoLSdEAbBiM9DFXoll9w==",
+      "version": "5.106.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -20086,9 +20142,8 @@
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
         "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
@@ -20252,19 +20307,19 @@
       }
     },
     "node_modules/webpack-dev-middleware/node_modules/memfs": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.1.tgz",
-      "integrity": "sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -36,14 +36,17 @@
   "atlasTranslations": {
     "dependencies": [
       "@openedx/frontend-app-authn",
-      "@openedx/frontend-app-learner-dashboard"
+      "@openedx/frontend-app-learner-dashboard",
+      "@openedx/frontend-app-instructor-dashboard",
+      "@openedx/frontend-app-notifications"
     ]
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
+    "@openedx/brand-openedx": "^2.0.0",
     "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
     "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
     "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",
+    "@openedx/frontend-app-notifications": "^3.0.0-alpha || 0.0.0-dev",
     "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
   },
   "devDependencies": {

--- a/site.config.build.tsx
+++ b/site.config.build.tsx
@@ -2,8 +2,11 @@ import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@o
 import { authnApp } from '@openedx/frontend-app-authn';
 import { instructorDashboardApp } from '@openedx/frontend-app-instructor-dashboard';
 import { learnerDashboardApp } from '@openedx/frontend-app-learner-dashboard';
+import { notificationsApp } from '@openedx/frontend-app-notifications';
 
-import './src/site.scss';
+import '@openedx/frontend-base/shell/style';
+import '@openedx/brand-openedx/core.min.css';
+import '@openedx/brand-openedx/light.min.css';
 
 const siteConfig: SiteConfig = {
   siteId: 'frontend-template-site',
@@ -21,6 +24,7 @@ const siteConfig: SiteConfig = {
     authnApp,
     learnerDashboardApp,
     instructorDashboardApp,
+    notificationsApp,
   ],
   externalRoutes: [
     {

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -2,8 +2,11 @@ import { EnvironmentTypes, SiteConfig, footerApp, headerApp, shellApp } from '@o
 import { authnApp } from '@openedx/frontend-app-authn';
 import { instructorDashboardApp } from '@openedx/frontend-app-instructor-dashboard';
 import { learnerDashboardApp } from '@openedx/frontend-app-learner-dashboard';
+import { notificationsApp } from '@openedx/frontend-app-notifications';
 
-import './src/site.scss';
+import '@openedx/frontend-base/shell/style';
+import '@openedx/brand-openedx/core.min.css';
+import '@openedx/brand-openedx/light.min.css';
 
 const siteConfig: SiteConfig = {
   siteId: 'frontend-template-dev',
@@ -21,6 +24,7 @@ const siteConfig: SiteConfig = {
     authnApp,
     learnerDashboardApp,
     instructorDashboardApp,
+    notificationsApp,
   ],
   externalRoutes: [
     {

--- a/src/site.scss
+++ b/src/site.scss
@@ -1,4 +1,0 @@
-@use '@openedx/frontend-base/shell/app.scss' as shell;
-@use '@openedx/frontend-app-authn/app.scss' as authn;
-@use '@openedx/frontend-app-learner-dashboard/app.scss' as learnerDashboard;
-@use '@openedx/frontend-app-instructor-dashboard/app.scss' as instructorDashboard;


### PR DESCRIPTION
### Description

Conforms to the updated CSS ownership model in `frontend-base`, where the composing site owns global styles and apps manage their own. Imports the shell style manifest (`@openedx/frontend-base/shell/style`) and brand CSS directly from the `site.config.*.tsx` files, removing the intermediate `src/site.scss`.

Uses `@openedx/brand-openedx` directly instead of the `@edx/brand` alias (no need for the alias since `package.json` and the site configs are themselves configuration), and bumps it to v2.

Also adds `notificationsApp` to both the build and dev site configs.

### TODO

Needs a package-lock update once the apps have been updated themselves.

### LLM usage notice

Built with assistance from Claude.