### PR TITLE
chore: add build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: node_CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - '**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Nodejs
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Build
+      run: npm run build


### PR DESCRIPTION
### Description

There was no CI workflow in this repo, so nothing caught webpack build breakage on pull requests. This PR adds a minimal GitHub Actions workflow that installs dependencies and runs `npm run build` on pushes to `main` and on all pull requests.

Refs openedx/frontend-base#124.

### LLM usage notice

Built with assistance from Claude.