### PR TITLE
chore: add dev SUPPORT_URL config for help button verification

### DIFF
--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -15,6 +15,9 @@ const siteConfig: SiteConfig = {
   lmsBaseUrl: 'http://local.openedx.io:8000',
   loginUrl: 'http://local.openedx.io:8000/login',
   logoutUrl: 'http://local.openedx.io:8000/logout',
+  commonAppConfig: {
+    SUPPORT_URL: 'https://example.com/help/',
+  },
 
   environment: EnvironmentTypes.DEVELOPMENT,
   apps: [
@@ -23,7 +26,13 @@ const siteConfig: SiteConfig = {
     footerApp,
     authnApp,
     learnerDashboardApp,
-    instructorDashboardApp,
+    {
+      ...instructorDashboardApp,
+      config: {
+        ...instructorDashboardApp.config,
+        SUPPORT_URL: 'https://example.com/help/instructor',
+      },
+    },
     notificationsApp,
   ],
   externalRoutes: [


### PR DESCRIPTION
## Summary

Companion PR to openedx/frontend-base#251. Adds `commonAppConfig.SUPPORT_URL` and an instructor-dashboard per-app override in `site.config.dev.tsx` so the help button can be verified locally without standing up a backend.

`site.config.build.tsx` is intentionally not modified — these are example URLs for local dev and shouldn't ship in production builds.

This PR is independent of the others — it's just dev-config scaffolding. Useful to merge whenever, since the dev experience without it is "configure your own URLs to verify."

## Test plan

- [ ] `make dev-packages` — dev site comes up
- [ ] Visit a learner-dashboard route → Help link appears, points to `https://example.com/help/`
- [ ] Visit an instructor-dashboard route → Help link points to `https://example.com/help/instructor` (per-app override wins over commonAppConfig)
- [ ] Comment out `commonAppConfig.SUPPORT_URL` and the instructor override → Help link disappears on both routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)