### PR TITLE
chore: downgrade @openedx/brand-openedx to ^1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@openedx/brand-openedx": "^2.0.0",
+        "@openedx/brand-openedx": "^1.2.3",
         "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
         "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",
         "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
@@ -4182,9 +4182,9 @@
       }
     },
     "node_modules/@openedx/brand-openedx": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-2.0.4.tgz",
-      "integrity": "sha512-3iGs4ZjfOsyN1msP+Wn/k11qL4g0CJGpKWGH5f248n+dZrGzZnhyz2CEo4TCRRMqOcQroSX5WBIuZR4vUla0Sg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@openedx/frontend-app-authn": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "@openedx/brand-openedx": "^2.0.0",
+    "@openedx/brand-openedx": "^1.2.3",
     "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
     "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
     "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",

--- a/site.config.build.tsx
+++ b/site.config.build.tsx
@@ -5,8 +5,6 @@ import { learnerDashboardApp } from '@openedx/frontend-app-learner-dashboard';
 import { notificationsApp } from '@openedx/frontend-app-notifications';
 
 import '@openedx/frontend-base/shell/style';
-import '@openedx/brand-openedx/core.min.css';
-import '@openedx/brand-openedx/light.min.css';
 
 const siteConfig: SiteConfig = {
   siteId: 'frontend-template-site',

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -5,8 +5,6 @@ import { learnerDashboardApp } from '@openedx/frontend-app-learner-dashboard';
 import { notificationsApp } from '@openedx/frontend-app-notifications';
 
 import '@openedx/frontend-base/shell/style';
-import '@openedx/brand-openedx/core.min.css';
-import '@openedx/brand-openedx/light.min.css';
 
 const siteConfig: SiteConfig = {
   siteId: 'frontend-template-dev',


### PR DESCRIPTION
### Description

Downgrades `@openedx/brand-openedx` from `^2.0.0` to the latest 1.x release (`^1.2.3`), matching the parallel downgrade across released MFEs tracked by openedx/public-engineering#508. Since v2 introduces breaking changes that the rest of the released MFE set is not yet prepared to absorb, this template should ship a 1.x default.

### LLM usage notice

Built with assistance from Claude.