### PR TITLE
chore: add cmsBaseUrl to site configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4490,9 +4490,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-instructor-dashboard": {
-      "version": "1.0.0-alpha.32",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0-alpha.32.tgz",
-      "integrity": "sha512-YpiQ9yMh810P2I3PiEmHHgYimjlBJbaH+vznQcsaYn8fX6ak0G2UZCO5Hf+FuYkKNBX0l1TuJpplUbZbASag7Q==",
+      "version": "1.0.0-alpha.36",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0-alpha.36.tgz",
+      "integrity": "sha512-mfayTcvHKgyuC9aoM6VmvODgYwxvcSIafCIGRdzkh30GFz460uoh/QN3x5gVZeEuZYuojDJVOWcFK72E/DwsNQ==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.42.tgz",
-      "integrity": "sha512-3qpoazcIqYc9xqujG/MBs4dNpWGOcGC26+UdTcr5Q2+S08NfEyqg0kUOJTVKh6JjW1F3/RuUGDvrxKtmOWgs2g==",
+      "version": "1.0.0-alpha.46",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.46.tgz",
+      "integrity": "sha512-NxmgyTGirG+FlEbp3FM4cdwOMqjMEL465egHrNUjk82+hxxwnGBe3tpHzMEjsbRVQMIEay0+PziLi9Si6nbBvg==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.24.9",

--- a/site.config.build.tsx
+++ b/site.config.build.tsx
@@ -13,6 +13,7 @@ const siteConfig: SiteConfig = {
   siteName: 'Frontend Template Site',
   baseUrl: 'http://apps.local.openedx.io',
   lmsBaseUrl: 'http://local.openedx.io',
+  cmsBaseUrl: 'http://studio.local.openedx.io',
   loginUrl: 'http://local.openedx.io/login',
   logoutUrl: 'http://local.openedx.io/logout',
 

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -13,6 +13,7 @@ const siteConfig: SiteConfig = {
   siteName: 'Frontend Template Dev',
   baseUrl: 'http://apps.local.openedx.io:8080',
   lmsBaseUrl: 'http://local.openedx.io:8000',
+  cmsBaseUrl: 'http://studio.local.openedx.io:8001',
   loginUrl: 'http://local.openedx.io:8000/login',
   logoutUrl: 'http://local.openedx.io:8000/logout',
   commonAppConfig: {


### PR DESCRIPTION
### Description

Adds `cmsBaseUrl` to the dev and build site configs so the masquerade bar's Studio link can render.

Depends on the `cmsBaseUrl` field landing in `frontend-base` (openedx/frontend-base#260).

### LLM usage notice

Built with assistance from Claude.