### PR TITLE
docs: add site-messages README

### DIFF
--- a/src/i18n/site-messages/README.md
+++ b/src/i18n/site-messages/README.md
@@ -1,0 +1,2 @@
+Place site-local translation JSON files here (e.g. `ar.json`, `fr.json`).
+They are merged in last, so they can override strings from pulled packages.


### PR DESCRIPTION
## What

Adds `src/i18n/site-messages/README.md` documenting the operator-managed local translations directory.

## Why

The frontend-base i18n pipeline added in [openedx/frontend-base#205](https://github.com/openedx/frontend-base/pull/205) (part of [openedx/frontend-base#176](https://github.com/openedx/frontend-base/issues/176)) introduced `src/i18n/site-messages/` as the checked-in, operator-managed location for site-local translation JSON files. The layout in this repo is:

```
src/i18n/
├── index.js              ← checked in, re-exports from messages.ts
├── messages.d.ts         ← checked in, TypeScript type stub
├── messages.ts           ← gitignored, generated by translations:prepare
├── messages/             ← gitignored, populated by atlas pull
└── site-messages/        ← checked in, operator-managed local translations
    ├── README.md
    └── *.json            ← operator's own translations; merged in last (override behavior)
```

(The frontend-base migration guide documents this re-export module as `index.ts`; this repo landed it as `index.js` in #11 — that discrepancy is out of scope here.)

`translations:prepare` generates a gitignored `site-messages/index.ts` from the JSON files an operator drops in this directory, and those strings are merged in last so they can override strings pulled from packages. The repo's `.gitignore` already references `src/i18n/site-messages/index.ts`, but the directory itself and its explanatory README were never committed — the README only ever existed in the throwaway testing PR [#10](https://github.com/openedx/frontend-template-site/pull/10), which was closed without merging.

This adds the README so the directory exists in a fresh clone and operators understand what to put there. The content matches what was in PR #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
