### PR TITLE
chore: update dependencies to stable releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
       ],
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.3.0 || 0.0.0-dev",
-        "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-app-notifications": "^3.0.0-alpha || 0.0.0-dev",
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
+        "@openedx/frontend-app-authn": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-app-instructor-dashboard": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-app-learner-dashboard": "^1.0.0 || 0.0.0-dev",
+        "@openedx/frontend-app-notifications": "^3.0.0 || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev"
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.5.0",
@@ -4452,9 +4452,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-authn": {
-      "version": "1.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0-alpha.13.tgz",
-      "integrity": "sha512-hEn8YJ5Mee9ZBS0hgd7JErpZ1PgWrQg3erPgjoak4r5Eq7u036BpP/TCvUwBAM2thFyEMtYt6OlPsgfAXkjzQw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-authn/-/frontend-app-authn-1.0.0.tgz",
+      "integrity": "sha512-ZHP0KZQG7sStNMpBC1Qp90WkKk/HKVbQQmeE1yxHgR0isCj9DOLaHXyx6JecXEL1lrIsrwQj3Zmt1oWeXs+N0g==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4480,7 +4480,7 @@
         "node": "^24.12"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4490,9 +4490,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-instructor-dashboard": {
-      "version": "1.0.0-alpha.36",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0-alpha.36.tgz",
-      "integrity": "sha512-mfayTcvHKgyuC9aoM6VmvODgYwxvcSIafCIGRdzkh30GFz460uoh/QN3x5gVZeEuZYuojDJVOWcFK72E/DwsNQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-instructor-dashboard/-/frontend-app-instructor-dashboard-1.0.0.tgz",
+      "integrity": "sha512-zD2HzsZUPSgqPYeKdbePglre+SEAKSe2e8pl0lLsKkwuui9YM+aNsmhu8GaN8MTs8GQ7aZk+2E+pcbCrAa0Gdg==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4504,7 +4504,7 @@
         "react-helmet": "^6.1.0"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4514,9 +4514,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-learner-dashboard": {
-      "version": "1.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0-alpha.16.tgz",
-      "integrity": "sha512-mTpwz2GouA/5KZWsRs54ohwqzno1aNtsyUSGF+5CXDU5XhS8ZF2ZUr6j530iumtT67yR03wFcGMoy4SMyemC/Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-learner-dashboard/-/frontend-app-learner-dashboard-1.0.0.tgz",
+      "integrity": "sha512-maQRGegTlOXgftYWS28HA2iWT+2uMzo+g3VqKy3h/98w0EDY304wFuskCtcuaR2p8KgKl9NetKZ9ytsojGD3lA==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4536,7 +4536,7 @@
         "react-share": "^5.2.2"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "@types/react": "^18",
@@ -4597,9 +4597,9 @@
       }
     },
     "node_modules/@openedx/frontend-app-notifications": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-1hDyiTT3anZP52yaPs6Sng4Q5rzo5xZcwdhJxRhoRbBwDHgpnSNlOAks5wafm0S5qlcgDsHVYiD/NEnbJqwkig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-app-notifications/-/frontend-app-notifications-3.0.0.tgz",
+      "integrity": "sha512-BqvCkKCWuE+kztfScmKX5ovg2zT8MzFJke6c/JNXx4XzcHBz15bNVpMzAuZ4qBycyefX0d/a2HkggcuVxWMGBw==",
       "license": "AGPL-3.0",
       "workspaces": [
         "packages/*"
@@ -4617,7 +4617,7 @@
         "uuid": "^13.0.0"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.46",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.46.tgz",
-      "integrity": "sha512-NxmgyTGirG+FlEbp3FM4cdwOMqjMEL465egHrNUjk82+hxxwnGBe3tpHzMEjsbRVQMIEay0+PziLi9Si6nbBvg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
+      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.24.9",

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
   },
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.3.0 || 0.0.0-dev",
-    "@openedx/frontend-app-authn": "^1.0.0-alpha || 0.0.0-dev",
-    "@openedx/frontend-app-learner-dashboard": "^1.0.0-alpha || 0.0.0-dev",
-    "@openedx/frontend-app-instructor-dashboard": "^1.0.0-alpha || 0.0.0-dev",
-    "@openedx/frontend-app-notifications": "^3.0.0-alpha || 0.0.0-dev",
-    "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev"
+    "@openedx/frontend-app-authn": "^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-app-learner-dashboard": "^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-app-instructor-dashboard": "^1.0.0 || 0.0.0-dev",
+    "@openedx/frontend-app-notifications": "^3.0.0 || 0.0.0-dev",
+    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev"
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.5.0",


### PR DESCRIPTION
### Description

Now that `frontend-base` and the bundled apps have published stable releases to NPM, this points the template site at those stable versions instead of the `-alpha` prereleases, preserving the `|| 0.0.0-dev` local-development fallback.

Part of openedx/frontend-base#244.

### LLM usage notice

Built with assistance from Claude.